### PR TITLE
Feat/plugins architecture refactor

### DIFF
--- a/__tests__/utils/errors.test.ts
+++ b/__tests__/utils/errors.test.ts
@@ -1,10 +1,10 @@
 import {
-  DomainError,
   exitOnError,
   installGlobalErrorHandlers,
 } from '../../src/utils/errors';
 import { Logger } from '../../src/utils/logger';
 import telemetryUtils from '../../src/utils/telemetry';
+import { DomainError } from '../../src/core/errors';
 
 jest.mock('../../src/utils/telemetry', () => ({
   __esModule: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3774,17 +3774,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.4.2"
-      }
-    },
     "node_modules/anser": {
       "version": "1.4.10",
       "resolved": "https://registry.npmjs.org/anser/-/anser-1.4.10.tgz",
@@ -5924,20 +5913,6 @@
       "peer": true,
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/escodegen/node_modules/source-map": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-      "integrity": "sha512-CBdZ2oa/BHhS4xj5DlhjWNHcan57/5YuvfdLf17iVmIpd9KRm+DFLmC6nBNj+6Ua7Kt3TmOjDpQT1aTYOQtoUA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "amdefine": ">=0.0.4"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/escodegen/node_modules/type-check": {

--- a/src/commands/account/balance.ts
+++ b/src/commands/account/balance.ts
@@ -1,8 +1,8 @@
-import accountUtils from '../../utils/account';
-import { DomainError } from '../../utils/errors';
-import { isJsonOutput, printOutput } from '../../utils/output';
+// import accountUtils from '../../utils/account';
+// import { DomainError } from '../../utils/errors';
+// import { isJsonOutput, printOutput } from '../../utils/output';
 import { telemetryPreAction } from '../shared/telemetryHook';
-import { wrapAction } from '../shared/wrapAction';
+// import { wrapAction } from '../shared/wrapAction';
 
 import { Command } from 'commander';
 
@@ -18,39 +18,39 @@ export default (program: Command) => {
       '(Required) Account ID or account name to retrieve balance for',
     )
     .option('-h, --only-hbar', 'Show only Hbar balance')
-    .option('-t, --token-id <tokenId>', 'Show balance for a specific token ID')
-    .action(
-      wrapAction<GetAccountBalanceOptions>(
-        async (options) => {
-          if (options.onlyHbar && options.tokenId) {
-            throw new DomainError(
-              'You cannot use both --only-hbar and --token-id options at the same time.',
-            );
-          }
-          await accountUtils.getAccountBalance(
-            options.accountIdOrName,
-            options.onlyHbar,
-            options.tokenId,
-          );
-          if (isJsonOutput()) {
-            printOutput('accountBalance', {
-              target: options.accountIdOrName,
-              onlyHbar: options.onlyHbar || false,
-              tokenId: options.tokenId || null,
-            });
-          }
-        },
-        { log: (o) => `Getting balance for ${o.accountIdOrName}` },
-      ),
-    );
+    .option('-t, --token-id <tokenId>', 'Show balance for a specific token ID');
+  // .action(
+  //   wrapAction<GetAccountBalanceOptions>(
+  //     async (options) => {
+  //       if (options.onlyHbar && options.tokenId) {
+  //         throw new DomainError(
+  //           'You cannot use both --only-hbar and --token-id options at the same time.',
+  //         );
+  //       }
+  //       await accountUtils.getAccountBalance(
+  //         options.accountIdOrName,
+  //         options.onlyHbar,
+  //         options.tokenId,
+  //       );
+  //       if (isJsonOutput()) {
+  //         printOutput('accountBalance', {
+  //           target: options.accountIdOrName,
+  //           onlyHbar: options.onlyHbar || false,
+  //           tokenId: options.tokenId || null,
+  //         });
+  //       }
+  //     },
+  //     { log: (o) => `Getting balance for ${o.accountIdOrName}` },
+  //   ),
+  // );
   program.addHelpText(
     'afterAll',
     '\nExamples:\n  $ hedera account balance -a 0.0.1234\n  $ hedera account balance -a alice -h --json',
   );
 };
 
-interface GetAccountBalanceOptions {
-  onlyHbar: boolean;
-  tokenId: string;
-  accountIdOrName: string;
-}
+// interface GetAccountBalanceOptions {
+//   onlyHbar: boolean;
+//   tokenId: string;
+//   accountIdOrName: string;
+// }

--- a/src/commands/account/balance.ts
+++ b/src/commands/account/balance.ts
@@ -1,10 +1,10 @@
 import accountUtils from '../../utils/account';
-import { DomainError } from '../../utils/errors';
 import { isJsonOutput, printOutput } from '../../utils/output';
 import { telemetryPreAction } from '../shared/telemetryHook';
 import { wrapAction } from '../shared/wrapAction';
 
 import { Command } from 'commander';
+import { DomainError } from '../../core/errors';
 
 // logging handled via wrapAction config
 

--- a/src/commands/account/balance.ts
+++ b/src/commands/account/balance.ts
@@ -1,8 +1,8 @@
-// import accountUtils from '../../utils/account';
-// import { DomainError } from '../../utils/errors';
-// import { isJsonOutput, printOutput } from '../../utils/output';
+import accountUtils from '../../utils/account';
+import { DomainError } from '../../utils/errors';
+import { isJsonOutput, printOutput } from '../../utils/output';
 import { telemetryPreAction } from '../shared/telemetryHook';
-// import { wrapAction } from '../shared/wrapAction';
+import { wrapAction } from '../shared/wrapAction';
 
 import { Command } from 'commander';
 
@@ -18,39 +18,39 @@ export default (program: Command) => {
       '(Required) Account ID or account name to retrieve balance for',
     )
     .option('-h, --only-hbar', 'Show only Hbar balance')
-    .option('-t, --token-id <tokenId>', 'Show balance for a specific token ID');
-  // .action(
-  //   wrapAction<GetAccountBalanceOptions>(
-  //     async (options) => {
-  //       if (options.onlyHbar && options.tokenId) {
-  //         throw new DomainError(
-  //           'You cannot use both --only-hbar and --token-id options at the same time.',
-  //         );
-  //       }
-  //       await accountUtils.getAccountBalance(
-  //         options.accountIdOrName,
-  //         options.onlyHbar,
-  //         options.tokenId,
-  //       );
-  //       if (isJsonOutput()) {
-  //         printOutput('accountBalance', {
-  //           target: options.accountIdOrName,
-  //           onlyHbar: options.onlyHbar || false,
-  //           tokenId: options.tokenId || null,
-  //         });
-  //       }
-  //     },
-  //     { log: (o) => `Getting balance for ${o.accountIdOrName}` },
-  //   ),
-  // );
+    .option('-t, --token-id <tokenId>', 'Show balance for a specific token ID')
+    .action(
+      wrapAction<GetAccountBalanceOptions>(
+        async (options) => {
+          if (options.onlyHbar && options.tokenId) {
+            throw new DomainError(
+              'You cannot use both --only-hbar and --token-id options at the same time.',
+            );
+          }
+          await accountUtils.getAccountBalance(
+            options.accountIdOrName,
+            options.onlyHbar,
+            options.tokenId,
+          );
+          if (isJsonOutput()) {
+            printOutput('accountBalance', {
+              target: options.accountIdOrName,
+              onlyHbar: options.onlyHbar || false,
+              tokenId: options.tokenId || null,
+            });
+          }
+        },
+        { log: (o) => `Getting balance for ${o.accountIdOrName}` },
+      ),
+    );
   program.addHelpText(
     'afterAll',
     '\nExamples:\n  $ hedera account balance -a 0.0.1234\n  $ hedera account balance -a alice -h --json',
   );
 };
 
-// interface GetAccountBalanceOptions {
-//   onlyHbar: boolean;
-//   tokenId: string;
-//   accountIdOrName: string;
-// }
+interface GetAccountBalanceOptions {
+  onlyHbar: boolean;
+  tokenId: string;
+  accountIdOrName: string;
+}

--- a/src/commands/account/delete.ts
+++ b/src/commands/account/delete.ts
@@ -3,11 +3,11 @@ import type { Account } from '../../../types/state';
 import { getState } from '../../state/store';
 import accountUtils from '../../utils/account';
 import enquirerUtils from '../../utils/enquirer';
-import { DomainError } from '../../utils/errors';
 import { isJsonOutput, printOutput } from '../../utils/output';
 import stateUtils from '../../utils/state';
 import { telemetryPreAction } from '../shared/telemetryHook';
 import { wrapAction } from '../shared/wrapAction';
+import { DomainError } from '../../core/errors';
 
 export default (program: Command) => {
   program

--- a/src/commands/backup.ts
+++ b/src/commands/backup.ts
@@ -9,12 +9,12 @@ import {
 } from '../state/store';
 import { addAccount, addToken, addScript } from '../state/mutations';
 import { Logger } from '../utils/logger';
-import { DomainError } from '../utils/errors';
 import { wrapAction } from './shared/wrapAction';
 
 import type { State, Account, Token, Script } from '../../types';
 import type { StoreState } from '../state/store';
 import type { Command as CommanderCommand } from 'commander';
+import { DomainError } from '../core/errors';
 
 // Local narrowed shapes for partial restores
 type AccountsOnly = Record<string, Account>;

--- a/src/commands/hbar.ts
+++ b/src/commands/hbar.ts
@@ -2,11 +2,11 @@ import { Command } from 'commander';
 import type { Account } from '../../types';
 import { getState } from '../state/store';
 import enquirerUtils from '../utils/enquirer';
-import { DomainError } from '../utils/errors';
 import hbarUtils from '../utils/hbar';
 import stateUtils from '../utils/state';
 import { telemetryPreAction } from './shared/telemetryHook';
 import { wrapAction } from './shared/wrapAction';
+import { DomainError } from '../core/errors';
 export default (program: Command) => {
   const hbar = program.command('hbar').alias('hb');
 

--- a/src/commands/script/load.ts
+++ b/src/commands/script/load.ts
@@ -3,12 +3,12 @@ import { Command } from 'commander';
 import type { Script } from '../../../types';
 import { getState } from '../../state/store';
 import { heading, success } from '../../utils/color';
-import { DomainError } from '../../utils/errors';
 import { Logger } from '../../utils/logger';
 import { isJsonOutput, printOutput } from '../../utils/output';
 import stateUtils from '../../utils/state';
 import { telemetryPreAction } from '../shared/telemetryHook';
 import { wrapAction } from '../shared/wrapAction';
+import { DomainError } from '../../core/errors';
 
 const logger = Logger.getInstance();
 

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -6,12 +6,12 @@ import {
   saveState as storeSaveState,
 } from '../state/store';
 import accountUtils from '../utils/account';
-import { DomainError } from '../utils/errors';
 import { Logger } from '../utils/logger';
 import setupUtils from '../utils/setup';
 import stateUtils from '../utils/state';
 import { telemetryPreAction } from './shared/telemetryHook';
 import { wrapAction } from './shared/wrapAction';
+import { DomainError } from '../core/errors';
 
 const logger = Logger.getInstance();
 

--- a/src/commands/shared/wrapAction.ts
+++ b/src/commands/shared/wrapAction.ts
@@ -1,6 +1,7 @@
 import dynamicVariablesUtils from '../../utils/dynamicVariables';
 import { exitOnError } from '../../utils/errors';
 import { Logger } from '../../utils/logger';
+import { AnyOptions } from '../../core/interfaces';
 
 const logger = Logger.getInstance();
 
@@ -15,7 +16,7 @@ export interface WrapConfig<T> {
  * 2. Emit a verbose log (optional)
  * 3. Apply standard error handling via exitOnError
  */
-export function wrapAction<T extends Record<string, any>>( // eslint-disable-line @typescript-eslint/no-explicit-any
+export function wrapAction<T extends AnyOptions>(
   handler: (opts: T) => Promise<void> | void,
   config?: WrapConfig<T>,
 ) {

--- a/src/commands/state/download.ts
+++ b/src/commands/state/download.ts
@@ -1,9 +1,9 @@
 import { Command } from 'commander';
-import { DomainError } from '../../utils/errors';
 import { isJsonOutput, printOutput } from '../../utils/output';
 import stateUtils from '../../utils/state';
 import { telemetryPreAction } from '../shared/telemetryHook';
 import { wrapAction } from '../shared/wrapAction';
+import { DomainError } from '../../core/errors';
 
 export default (program: Command) => {
   program

--- a/src/commands/telemetry.ts
+++ b/src/commands/telemetry.ts
@@ -1,8 +1,8 @@
 import { Command } from 'commander';
 import { saveKey as storeSaveKey } from '../state/store';
-import { DomainError } from '../utils/errors';
 import { Logger } from '../utils/logger';
 import { wrapAction } from './shared/wrapAction';
+import { DomainError } from '../core/errors';
 
 const logger = Logger.getInstance();
 

--- a/src/commands/token/create.ts
+++ b/src/commands/token/create.ts
@@ -4,7 +4,6 @@ import type { Token } from '../../../types/state';
 import { addToken } from '../../state/mutations';
 import { heading, success } from '../../utils/color';
 import dynamicVariablesUtils from '../../utils/dynamicVariables';
-import { DomainError } from '../../utils/errors';
 import { Logger } from '../../utils/logger';
 import { isJsonOutput, printOutput } from '../../utils/output';
 import signUtils from '../../utils/sign';
@@ -13,6 +12,7 @@ import tokenUtils from '../../utils/token';
 import { myParseInt } from '../../utils/verification';
 import { telemetryPreAction } from '../shared/telemetryHook';
 import { wrapAction } from '../shared/wrapAction';
+import { DomainError } from '../../core/errors';
 
 const logger = Logger.getInstance();
 

--- a/src/commands/topic/create.ts
+++ b/src/commands/topic/create.ts
@@ -4,13 +4,13 @@ import type { Topic } from '../../../types';
 import { addTopic } from '../../state/mutations';
 import { heading, success } from '../../utils/color';
 import dynamicVariablesUtils from '../../utils/dynamicVariables';
-import { DomainError } from '../../utils/errors';
 import { Logger } from '../../utils/logger';
 import { isJsonOutput, printOutput } from '../../utils/output';
 import signUtils from '../../utils/sign';
 import stateUtils from '../../utils/state';
 import { telemetryPreAction } from '../shared/telemetryHook';
 import { wrapAction } from '../shared/wrapAction';
+import { DomainError } from '../../core/errors';
 
 const logger = Logger.getInstance();
 

--- a/src/commands/topic/message.ts
+++ b/src/commands/topic/message.ts
@@ -5,12 +5,12 @@ import api from '../../api';
 import { selectTopics } from '../../state/selectors';
 import { heading, success, warn } from '../../utils/color';
 import dynamicVariablesUtils from '../../utils/dynamicVariables';
-import { DomainError } from '../../utils/errors';
 import { Logger } from '../../utils/logger';
 import { isJsonOutput, printOutput } from '../../utils/output';
 import stateUtils from '../../utils/state';
 import { telemetryPreAction } from '../shared/telemetryHook';
 import { wrapAction } from '../shared/wrapAction';
+import { DomainError } from '../../core/errors';
 
 const logger = Logger.getInstance();
 

--- a/src/core/core-api/account.ts
+++ b/src/core/core-api/account.ts
@@ -1,0 +1,13 @@
+import { getAccountBalance } from '../../utils/account';
+
+export class AccountApi {
+  constructor() {}
+
+  async getAccountBalance(
+    accountIdOrName: string,
+    onlyHbar: boolean = false,
+    tokenId?: string,
+  ): Promise<void> {
+    return getAccountBalance(accountIdOrName, onlyHbar, tokenId);
+  }
+}

--- a/src/core/core-api/coreApi.ts
+++ b/src/core/core-api/coreApi.ts
@@ -1,0 +1,12 @@
+import { AccountApi } from './account';
+import { OutputApi } from './output';
+
+export class CoreApi {
+  public account: AccountApi;
+  public output: OutputApi;
+
+  constructor() {
+    this.account = new AccountApi();
+    this.output = new OutputApi();
+  }
+}

--- a/src/core/core-api/index.ts
+++ b/src/core/core-api/index.ts
@@ -1,0 +1,1 @@
+export { CoreApi } from './coreApi';

--- a/src/core/core-api/output.ts
+++ b/src/core/core-api/output.ts
@@ -1,0 +1,20 @@
+export class OutputApi {
+  private outputState = {
+    json: false,
+  };
+
+  public isJsonOutput() {
+    return this.outputState.json;
+  }
+
+  public printOutput(human: string, data?: unknown) {
+    if (this.outputState.json) {
+      const payload = data !== undefined ? data : { message: human };
+      // eslint-disable-next-line no-console
+      console.log(JSON.stringify(payload, null, 2));
+    } else {
+      // eslint-disable-next-line no-console
+      console.log(human);
+    }
+  }
+}

--- a/src/core/errors/index.ts
+++ b/src/core/errors/index.ts
@@ -1,0 +1,15 @@
+export class DomainError extends Error {
+  public code: number;
+
+  constructor(message: string, code = 1) {
+    super(message);
+    this.name = 'DomainError';
+    this.code = code;
+  }
+}
+
+export const errors = {
+  DomainError,
+};
+
+export type Errors = typeof errors;

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -1,3 +1,5 @@
+import { WrapConfig } from '../commands/shared/wrapAction';
+
 export interface PluginManifest {
   name: string;
   version: string;
@@ -5,7 +7,7 @@ export interface PluginManifest {
   description?: string;
   compatibility: { cli: string; core: string; api?: string };
   capabilities: string[];
-  commands: CommandSpec[];
+  commands: CommandSpec<any>[]; // eslint-disable-line @typescript-eslint/no-explicit-any
   stateSchemas?: Array<{
     namespace: string;
     version: number;
@@ -29,6 +31,7 @@ export interface CommandSpec<Options extends AnyOptions = AnyOptions> {
   description?: string;
   options: Array<CommandOption>;
   handler: (options: Options) => void | Promise<void>; // path within plugin package
+  config?: WrapConfig<Options>;
 }
 
 export interface CommandHandlerArgs {

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -1,0 +1,38 @@
+export interface PluginManifest {
+  name: string;
+  version: string;
+  cliName: string;
+  description?: string;
+  compatibility: { cli: string; core: string; api?: string };
+  capabilities: string[];
+  commands: CommandSpec[];
+  stateSchemas?: Array<{
+    namespace: string;
+    version: number;
+    jsonSchema: unknown;
+    scope?: 'profile' | 'global';
+  }>;
+}
+
+export interface CommandSpec {
+  name: string; // e.g., 'token create',
+  cliName: string;
+  summary?: string;
+  description?: string;
+  options?: Array<{
+    name: string;
+    type: 'string' | 'number' | 'boolean' | 'array';
+    required?: boolean;
+    default?: unknown;
+  }>;
+  handler: () => void; // path within plugin package
+}
+
+export interface CommandHandlerArgs {
+  // args: Record<string, unknown>;
+  // api: CoreAPI; // injected instance per execution
+  // state: StateManager; // namespaced access provided by Core
+  // config: ConfigView;
+  // telemetry: Telemetry;
+  // logger: Logger;
+}

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -14,18 +14,21 @@ export interface PluginManifest {
   }>;
 }
 
-export interface CommandSpec {
-  name: string; // e.g., 'token create',
+export interface CommandOption {
+  flags: string;
+  description: string;
+  required?: boolean;
+}
+
+export type AnyOptions = Record<string, any>; // eslint-disable-line @typescript-eslint/no-explicit-any
+
+export interface CommandSpec<Options extends AnyOptions = AnyOptions> {
+  name: string;
   cliName: string;
   summary?: string;
   description?: string;
-  options?: Array<{
-    name: string;
-    type: 'string' | 'number' | 'boolean' | 'array';
-    required?: boolean;
-    default?: unknown;
-  }>;
-  handler: () => void; // path within plugin package
+  options: Array<CommandOption>;
+  handler: (options: Options) => void | Promise<void>; // path within plugin package
 }
 
 export interface CommandHandlerArgs {

--- a/src/core/interfaces.ts
+++ b/src/core/interfaces.ts
@@ -1,4 +1,6 @@
 import { WrapConfig } from '../commands/shared/wrapAction';
+import { CoreApi } from './core-api';
+import { Errors } from './errors';
 
 export interface PluginManifest {
   name: string;
@@ -30,13 +32,14 @@ export interface CommandSpec<Options extends AnyOptions = AnyOptions> {
   summary?: string;
   description?: string;
   options: Array<CommandOption>;
-  handler: (options: Options) => void | Promise<void>; // path within plugin package
+  handler: (options: Options, api: CommandHandlerArgs) => void | Promise<void>; // path within plugin package
   config?: WrapConfig<Options>;
 }
 
 export interface CommandHandlerArgs {
+  api: CoreApi;
+  errors: Errors;
   // args: Record<string, unknown>;
-  // api: CoreAPI; // injected instance per execution
   // state: StateManager; // namespaced access provided by Core
   // config: ConfigView;
   // telemetry: Telemetry;

--- a/src/core/plugins/account/balance.command.ts
+++ b/src/core/plugins/account/balance.command.ts
@@ -48,4 +48,7 @@ export const balanceCommand: CommandSpec<GetAccountBalanceOptions> = {
       });
     }
   },
+  config: {
+    log: (o) => `Getting balance for ${o.accountIdOrName}`,
+  },
 };

--- a/src/core/plugins/account/balance.command.ts
+++ b/src/core/plugins/account/balance.command.ts
@@ -1,11 +1,51 @@
 import { CommandSpec } from '../../interfaces';
+import { DomainError } from '../../../utils/errors';
+import accountUtils from '../../../utils/account';
+import { isJsonOutput, printOutput } from '../../../utils/output';
 
-export const balanceCommand: CommandSpec = {
+interface GetAccountBalanceOptions {
+  accountIdOrName: string;
+  onlyHbar: boolean;
+  tokenId: string;
+}
+
+export const balanceCommand: CommandSpec<GetAccountBalanceOptions> = {
   name: 'Balance Command',
   cliName: 'balance',
-  description: 'Check balance of your Hedera Account',
-  options: [],
-  handler: () => {
-    console.log('Example command result...');
+  description: 'Retrieve the balance for an account ID or name',
+  options: [
+    {
+      flags: '-a, --account-id-or-name <accountIdOrName>',
+      description:
+        '(Required) Account ID or account name to retrieve balance for',
+      required: true,
+    },
+    {
+      flags: '-h, --only-hbar',
+      description: 'Show only Hbar balance',
+    },
+    {
+      flags: '-t, --token-id <tokenId>',
+      description: 'Show balance for a specific token ID',
+    },
+  ],
+  async handler(options) {
+    if (options.onlyHbar && options.tokenId) {
+      throw new DomainError(
+        'You cannot use both --only-hbar and --token-id options at the same time.',
+      );
+    }
+    await accountUtils.getAccountBalance(
+      options.accountIdOrName,
+      options.onlyHbar,
+      options.tokenId,
+    );
+    if (isJsonOutput()) {
+      printOutput('accountBalance', {
+        target: options.accountIdOrName,
+        onlyHbar: options.onlyHbar || false,
+        tokenId: options.tokenId || null,
+      });
+    }
   },
 };

--- a/src/core/plugins/account/balance.command.ts
+++ b/src/core/plugins/account/balance.command.ts
@@ -1,0 +1,11 @@
+import { CommandSpec } from '../../interfaces';
+
+export const balanceCommand: CommandSpec = {
+  name: 'Balance Command',
+  cliName: 'balance',
+  description: 'Check balance of your Hedera Account',
+  options: [],
+  handler: () => {
+    console.log('Example command result...');
+  },
+};

--- a/src/core/plugins/account/balance.ts
+++ b/src/core/plugins/account/balance.ts
@@ -1,7 +1,4 @@
 import { CommandSpec } from '../../interfaces';
-import { DomainError } from '../../../utils/errors';
-import accountUtils from '../../../utils/account';
-import { isJsonOutput, printOutput } from '../../../utils/output';
 
 interface GetAccountBalanceOptions {
   accountIdOrName: string;
@@ -29,19 +26,21 @@ export const balanceCommand: CommandSpec<GetAccountBalanceOptions> = {
       description: 'Show balance for a specific token ID',
     },
   ],
-  async handler(options) {
+  async handler(options, { api, errors }) {
     if (options.onlyHbar && options.tokenId) {
-      throw new DomainError(
+      throw new errors.DomainError(
         'You cannot use both --only-hbar and --token-id options at the same time.',
       );
     }
-    await accountUtils.getAccountBalance(
+
+    await api.account.getAccountBalance(
       options.accountIdOrName,
       options.onlyHbar,
       options.tokenId,
     );
-    if (isJsonOutput()) {
-      printOutput('accountBalance', {
+
+    if (api.output.isJsonOutput()) {
+      api.output.printOutput('accountBalance', {
         target: options.accountIdOrName,
         onlyHbar: options.onlyHbar || false,
         tokenId: options.tokenId || null,

--- a/src/core/plugins/account/index.ts
+++ b/src/core/plugins/account/index.ts
@@ -1,0 +1,17 @@
+import { PluginManifest } from '../../interfaces';
+import { balanceCommand } from './balance.command';
+
+export const accountPlugin: PluginManifest = {
+  name: 'Account Plugin',
+  cliName: 'account',
+  description: 'Perform operations across your Hedera account.',
+  capabilities: [],
+  commands: [balanceCommand],
+  compatibility: {
+    api: '0.1',
+    cli: '0.1',
+    core: '0.1',
+  },
+  version: '1.0',
+  stateSchemas: [],
+};

--- a/src/core/plugins/account/index.ts
+++ b/src/core/plugins/account/index.ts
@@ -1,5 +1,5 @@
 import { PluginManifest } from '../../interfaces';
-import { balanceCommand } from './balance.command';
+import { balanceCommand } from './balance';
 
 export const accountPlugin: PluginManifest = {
   name: 'Account Plugin',

--- a/src/core/register-plugins.ts
+++ b/src/core/register-plugins.ts
@@ -34,6 +34,8 @@ export function registerPlugin(program: Command, plugin: PluginManifest) {
   }
 
   for (const command of plugin.commands) {
+    // @TODO Type safety for register commands
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     registerCommand(root, command);
   }
 }

--- a/src/core/register-plugins.ts
+++ b/src/core/register-plugins.ts
@@ -1,0 +1,39 @@
+import { CommandOption, CommandSpec, PluginManifest } from './interfaces';
+import { Command } from 'commander';
+import { wrapAction } from '../commands/shared/wrapAction';
+
+function registerOption(cmd: Command, option: CommandOption) {
+  if (option.required) {
+    return cmd.requiredOption(option.flags, option.description);
+  }
+
+  return cmd.option(option.flags, option.description);
+}
+
+function registerCommand(root: Command, command: CommandSpec) {
+  let cmd = root.command(command.cliName);
+
+  if (command.description) {
+    cmd = cmd.description(command.description);
+  }
+
+  for (const option of command.options) {
+    cmd = registerOption(cmd, option);
+  }
+
+  cmd.action(wrapAction(command.handler));
+
+  return cmd;
+}
+
+export function registerPlugin(program: Command, plugin: PluginManifest) {
+  let root = program.command(plugin.cliName);
+
+  if (plugin.description) {
+    root = root.description(plugin.description);
+  }
+
+  for (const command of plugin.commands) {
+    registerCommand(root, command);
+  }
+}

--- a/src/core/setup-cmd.ts
+++ b/src/core/setup-cmd.ts
@@ -1,0 +1,57 @@
+import { Logger } from '../utils/logger';
+import { program } from 'commander';
+import { setColorEnabled } from '../utils/color';
+import { setGlobalOutputMode } from '../utils/output';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const pkgPath = path.join(__dirname, '../../package.json');
+const pkg = fs.readFileSync(pkgPath, 'utf-8') as { version?: string };
+const logger = Logger.getInstance();
+
+export function setupCmd() {
+  program
+    .version(pkg.version || '0.0.0')
+    .description('A CLI tool for managing Hedera environments')
+    .option('-v, --verbose', 'Enable verbose logging')
+    .option('-q, --quiet', 'Quiet mode (only errors)')
+    .option(
+      '--debug',
+      'Enable debug logging (shows API URLs, network info, etc.)',
+    )
+    .option('--json', 'Machine-readable JSON output where supported')
+    .option('--no-color', 'Disable ANSI colors in output')
+    .option(
+      '--log-mode <mode>',
+      'Explicit log mode (normal|verbose|quiet|silent)',
+    );
+
+  // Ensure logging mode is applied before any command action executes.
+  program.hook('preAction', () => {
+    const opts = program.opts<{
+      verbose?: boolean;
+      quiet?: boolean;
+      debug?: boolean;
+      logMode?: string;
+      json?: boolean;
+      color?: boolean; // from --no-color inverse boolean option
+    }>();
+
+    // Handle debug flag (highest priority)
+    if (opts.debug) {
+      process.env.HCLI_DEBUG = 'true';
+    }
+
+    if (opts.logMode) {
+      const mode = opts.logMode as 'verbose' | 'quiet' | 'normal' | 'silent';
+      if (mode === 'silent') logger.setMode('silent');
+      else if (mode === 'verbose' || mode === 'quiet' || mode === 'normal')
+        logger.setLevel(mode);
+    } else if (opts.verbose) logger.setLevel('verbose');
+    else if (opts.quiet) logger.setLevel('quiet');
+    setColorEnabled(opts.color !== false);
+    setGlobalOutputMode({ json: Boolean(opts.json) });
+  });
+
+  return program;
+}

--- a/src/hedera-cli.ts
+++ b/src/hedera-cli.ts
@@ -6,14 +6,17 @@ import { PluginManifest } from './core/interfaces';
 import { accountPlugin } from './core/plugins/account';
 import { setupCmd } from './core/setup-cmd';
 import { registerPlugin } from './core/register-plugins';
+import { CoreApi } from './core/core-api';
 
 setupCmd();
 installGlobalErrorHandlers();
 
+const core = new CoreApi();
+
 const plugins: PluginManifest[] = [accountPlugin];
 
 for (const plugin of plugins) {
-  registerPlugin(program, plugin);
+  registerPlugin(program, plugin, core);
 }
 
 void program.parseAsync(process.argv);

--- a/src/hedera-cli.ts
+++ b/src/hedera-cli.ts
@@ -1,79 +1,19 @@
 #!/usr/bin/env node
 
 import { program } from 'commander';
-import { setColorEnabled } from './utils/color';
 import { installGlobalErrorHandlers } from './utils/errors';
-import { Logger } from './utils/logger';
-import { setGlobalOutputMode } from './utils/output';
 import { PluginManifest } from './core/interfaces';
 import { accountPlugin } from './core/plugins/account';
+import { setupCmd } from './core/setup-cmd';
+import { registerPlugin } from './core/register-plugins';
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const pkg = require('../package.json') as { version?: string };
-const logger = Logger.getInstance();
-
-program
-  .version(pkg.version || '0.0.0')
-  .description('A CLI tool for managing Hedera environments')
-  .option('-v, --verbose', 'Enable verbose logging')
-  .option('-q, --quiet', 'Quiet mode (only errors)')
-  .option(
-    '--debug',
-    'Enable debug logging (shows API URLs, network info, etc.)',
-  )
-  .option('--json', 'Machine-readable JSON output where supported')
-  .option('--no-color', 'Disable ANSI colors in output')
-  .option(
-    '--log-mode <mode>',
-    'Explicit log mode (normal|verbose|quiet|silent)',
-  );
-
-// Ensure logging mode is applied before any command action executes.
-program.hook('preAction', () => {
-  const opts = program.opts<{
-    verbose?: boolean;
-    quiet?: boolean;
-    debug?: boolean;
-    logMode?: string;
-    json?: boolean;
-    color?: boolean; // from --no-color inverse boolean option
-  }>();
-
-  // Handle debug flag (highest priority)
-  if (opts.debug) {
-    process.env.HCLI_DEBUG = 'true';
-  }
-
-  if (opts.logMode) {
-    const mode = opts.logMode as 'verbose' | 'quiet' | 'normal' | 'silent';
-    if (mode === 'silent') logger.setMode('silent');
-    else if (mode === 'verbose' || mode === 'quiet' || mode === 'normal')
-      logger.setLevel(mode);
-  } else if (opts.verbose) logger.setLevel('verbose');
-  else if (opts.quiet) logger.setLevel('quiet');
-  setColorEnabled(opts.color !== false);
-  setGlobalOutputMode({ json: Boolean(opts.json) });
-});
+setupCmd();
+installGlobalErrorHandlers();
 
 const plugins: PluginManifest[] = [accountPlugin];
 
-plugins.forEach((plugin) => {
-  const pluginRootCommand = program.command(plugin.cliName);
+for (const plugin of plugins) {
+  registerPlugin(program, plugin);
+}
 
-  plugin.commands.forEach((command) => {
-    pluginRootCommand.command(command.cliName).action(() => {
-      command.handler();
-    });
-  });
-});
-
-// // Auto-register all exported command registrar functions
-// Object.values(commands).forEach((register) => {
-//   if (typeof register === 'function') {
-//     register(program);
-//   }
-// });
-
-installGlobalErrorHandlers();
-
-program.parseAsync(process.argv);
+void program.parseAsync(process.argv);

--- a/src/state/mutations.ts
+++ b/src/state/mutations.ts
@@ -1,7 +1,7 @@
 import { Logger } from '../utils/logger';
-import { DomainError } from '../utils/errors';
 import type { Account, Token, Topic, Script } from '../../types';
 import { actions, getState } from './store';
+import { DomainError } from '../core/errors';
 
 const logger = Logger.getInstance();
 

--- a/src/utils/account.ts
+++ b/src/utils/account.ts
@@ -13,9 +13,9 @@ import { color, heading, warn } from '../utils/color';
 import { display } from '../utils/display';
 import { Logger } from '../utils/logger';
 import stateUtils from '../utils/state';
-import { DomainError } from './errors';
 
 import type { Account } from '../../types';
+import { DomainError } from '../core/errors';
 
 const logger = Logger.getInstance();
 
@@ -264,7 +264,7 @@ function importAccountId(id: string, name: string): Account {
   return account;
 }
 
-async function getAccountBalance(
+export async function getAccountBalance(
   accountIdOrName: string,
   onlyHbar: boolean = false,
   tokenId?: string,

--- a/src/utils/dynamicVariables.ts
+++ b/src/utils/dynamicVariables.ts
@@ -3,7 +3,7 @@ import {
   saveKey as storeSaveKey,
   type StoreState,
 } from '../state/store';
-import { DomainError } from './errors';
+import { DomainError } from '../core/errors';
 
 interface CommandAction {
   action: string;

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,15 +1,6 @@
 import telemetryUtils from './telemetry';
 import { Logger } from './logger';
-
-export class DomainError extends Error {
-  public code: number;
-
-  constructor(message: string, code = 1) {
-    super(message);
-    this.name = 'DomainError';
-    this.code = code;
-  }
-}
+import { DomainError } from '../core/errors';
 
 // Convenience helper to throw a DomainError (replaces scattered process.exit calls)
 export function fail(message: string, code = 1): never {

--- a/src/utils/fees.ts
+++ b/src/utils/fees.ts
@@ -5,8 +5,8 @@ import {
   AccountId,
   CustomFee,
 } from '@hashgraph/sdk';
-import { DomainError } from './errors';
 import { FixedFee, FractionalFee } from '../../types';
+import { DomainError } from '../core/errors';
 function createCustomFixedFee(fee: FixedFee): CustomFee {
   const customFee = new CustomFixedFee();
 

--- a/src/utils/hbar.ts
+++ b/src/utils/hbar.ts
@@ -2,8 +2,8 @@ import { TransferTransaction, Hbar, HbarUnit } from '@hashgraph/sdk';
 
 import stateUtils from './state';
 import { Logger } from '../utils/logger';
-import { DomainError } from './errors';
 import signUtils from './sign';
+import { DomainError } from '../core/errors';
 
 const logger = Logger.getInstance();
 

--- a/src/utils/script.ts
+++ b/src/utils/script.ts
@@ -1,9 +1,9 @@
 import { selectScripts } from '../state/selectors';
 import { updateState as storeUpdateState } from '../state/store';
 import { color, heading } from './color';
-import { DomainError } from './errors';
 import { Logger } from './logger';
 import { isJsonOutput, printOutput } from './output';
+import { DomainError } from '../core/errors';
 
 const logger = Logger.getInstance();
 

--- a/src/utils/sign.ts
+++ b/src/utils/sign.ts
@@ -1,5 +1,5 @@
 import { Transaction, PrivateKey } from '@hashgraph/sdk';
-import { DomainError } from './errors';
+import { DomainError } from '../core/errors';
 
 interface SigningRequirements {
   [action: string]: {

--- a/src/utils/state.ts
+++ b/src/utils/state.ts
@@ -15,7 +15,6 @@ import {
   saveState as storeSaveState,
   updateState as storeUpdateState,
 } from '../state/store';
-import { DomainError } from './errors';
 import { Logger } from './logger';
 
 import type {
@@ -27,6 +26,7 @@ import type {
   Token,
   Topic,
 } from '../../types';
+import { DomainError } from '../core/errors';
 
 const logger = Logger.getInstance();
 

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -5,10 +5,10 @@ import {
 } from '@hashgraph/sdk';
 
 import { Logger } from './logger';
-import { DomainError } from './errors';
 import api from '../api';
 import stateUtils from '../utils/state';
 import signUtils from '../utils/sign';
+import { DomainError } from '../core/errors';
 
 const logger = Logger.getInstance();
 


### PR DESCRIPTION
PR includes a gradual transition to a plugin architecture for easier functionality expansion and the ability to create plugins without access to the entire repository. 

In the current code, this has been achieved thanks to Core Api, but not all of the logic has been transferred, only wrappers for existing functions. This was done because transferring everything at once would be a difficult process to track and would cause various problems, which are described in more detail in the related issue.

Further development of this architecture will be provided in subsequent PRs.